### PR TITLE
Fix compile error seen using rust 1.15.1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn builds(executable: &String, target: &String) -> Result<Vec<String>> {
 }
 
 fn exec(executable: &String, action: &String, args: Vec<String>) -> Result<Child> {
-    Ok(Command::new(executable).arg(action).args(args).spawn()?)
+    Ok(Command::new(executable).arg(action).args(&args).spawn()?)
 }
 
 fn watch(


### PR DESCRIPTION
Compile error:
```sh
error[E0308]: mismatched types
   --> src/main.rs:104:50
    |
104 |     Ok(Command::new(executable).arg(action).args(args).spawn()?)
    |                                                  ^^^^ expected &[_], found struct `std::vec::Vec`
    |
    = note: expected type `&[_]`
    = note:    found type `std::vec::Vec<std::string::String>`
```