### PR TITLE
make `bazel query` try harder to get a list of dependencies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ fn buildfile(path: PathBuf) -> bool {
 fn query(executable: &String, q: String) -> Result<Vec<String>> {
     let query = Command::new(executable)
         .arg("query")
+        .arg("--keep_going")
         .arg(q)
         .output()
         .unwrap();


### PR DESCRIPTION
If I run `bazel build "//examples/macos/..."` in
https://github.com/bazelbuild/rules_apple then it works fine, but
if I run `bazel query "deps(//examples/macos/...)"` then it blows up
in my face, complaining about "no such package '@com_google_protobuf//'".

This causes rebazel to have empty list of files to watch.

This patch adds the `--keep_going` flag to `bazel query`, so we at
least end up with a partial list of files to watch. In practice, this was
enough to get rebuild-on-save to work for the example files that I
was editing.

I've not used bazel before, so I'm not sure how common this inability
to get deps is. Is this a reasonable hack, or should we instead listen
to the exit code of `bazel query` and abort, or trigger some kind of
fallback behaviour?